### PR TITLE
(TX2 Fix) Updating gtop to use command-line arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 all:
 	g++ -std=c++14 gtop.cc utils.cc display.cc -o gtop -pedantic -Wall -Wextra -lncurses -lpthread
 
+clean:
+	rm gtop
+
 fake:
 	g++ -std=c++14 gtop.cc utils.cc display.cc -o gtop -pedantic -Wall -Wextra -lncurses -lpthread -DTEGRASTATS_FAKE
 

--- a/display.cc
+++ b/display.cc
@@ -121,6 +121,11 @@ void display_cpu_stats(const int & row, const tegrastats & ts) {
   }
 }
 
+void display_emc_stats(const int & row, const tegrastats & ts) {
+  mvprintw(row, 0, "EMC");
+  display_bars(row, BAR_OFFSET, ts.emc_usage, ts.emc_freq);
+}
+
 void display_gpu_stats(const int & row, const tegrastats & ts) {
   mvprintw(row, 0, "GPU");
   display_bars(row, BAR_OFFSET, ts.gpu_usage, ts.gpu_freq);

--- a/display.hh
+++ b/display.hh
@@ -69,6 +69,7 @@ void clear_row(const int &, const int &);
 void display_cpu_stats(const int &, const tegrastats &);
 void display_gpu_stats(const int &, const tegrastats &);
 void display_mem_stats(const int &, const tegrastats &);
+void display_emc_stats(const int &, const tegrastats &);
 void display_usage_chart(const int &, const std::vector<std::vector<int>>);
 
 #endif // DISPLAY_HH_

--- a/gtop.hh
+++ b/gtop.hh
@@ -21,7 +21,7 @@
 #include "display.hh"
 #include "utils.hh"
 
-const int STATS_BUFFER_SIZE = 256;
+const int STATS_BUFFER_SIZE = 1024;
 
 const std::string TEGRASTATS_PATH     = "~/tegrastats";
 const std::string TEGRASTATSFAKE_PATH = "./tegrastats_fake";
@@ -33,6 +33,7 @@ void get_cpu_stats_tx1(tegrastats &, const std::string &);
 void get_cpu_stats_tx2(tegrastats &, const std::string &);
 void get_gpu_stats(tegrastats &, const std::string &);
 void get_mem_stats(tegrastats &, const std::string &);
+void get_emc_stats(tegrastats &, const std::string &);
 
 void display_stats(const dimensions &, const tegrastats &);
 void update_usage_chart(std::vector<std::vector<int>> &, const std::vector<int> &);

--- a/utils.hh
+++ b/utils.hh
@@ -22,6 +22,9 @@ struct tegrastats {
   int gpu_usage;
   int gpu_freq;
 
+  int emc_usage;
+  int emc_freq;
+  
   jetson_version version;
 };
 


### PR DESCRIPTION
 to specify the board type, not guess based on fields out of tegrastats. Added EMC plot.